### PR TITLE
Support for region-based scoring cards

### DIFF
--- a/FLUKA.py
+++ b/FLUKA.py
@@ -153,3 +153,18 @@ def HighLightComment(myString,begLine=None,endLine=None):
     if (begLine is None): begLine=begLineGLOB
     if (endLine is None): endLine=endLineGLOB
     return begLine+"\n* "+myString+" \n"+endLine
+
+def CheckString(myString,maxLen=8,nDigits=2,addChar="_",lDebug=True):
+    if (nDigits is None or nDigits<0): nDigits=0
+    nNameFmt=None
+    if (len(myString)>maxLen-nDigits):
+        newName=myString[0:maxLen-nDigits]
+        if (lDebug): print("...chopping name %s to len(%s)==%d"%(myString,newName,len(newName)))
+    elif (len(myString)<maxLen-nDigits):
+        newName=myString+addChar*(maxLen-nDigits-len(newName))
+        if (lDebug): print("...chopping name %s to len(%s)==%d"%(myString,newName,len(newName)))
+    else:
+        newName=myString
+    if (nDigits>0):
+        newNameFmt=newName+"%0"+"%d"%(maxLen-len(newName))+"d"
+    return newName, newNameFmt

--- a/geometry.py
+++ b/geometry.py
@@ -9,7 +9,7 @@ import grid
 from body import Body
 from region import Region
 from transformation import RotDefi, Transformation
-from scorings import Usrbin, Usryield
+from scorings import Usrbin, Usryield, Usrbdx
 from FLUKA import HighLightComment, CheckString
 
 class Geometry():
@@ -238,7 +238,17 @@ class Geometry():
                 lFound=True
             else:
                 for iEntry,myEntry in enumerate(self.scos):
-                    if (myEntry.echoName()==myValue):
+                    if (myEntry.echoName()==myValue and isinstance(myEntry,Usryield) ):
+                        lFound=True
+                        break
+        elif (myKey.upper().startswith("USRBDX")):
+            if (myValue.upper()=="ALL"):
+                myEntry=[ mySco.echoName() for mySco in self.scos if isinstance(mySco,Usrbdx) ]
+                iEntry=[ ii for ii in range(len(self.scos)) ]
+                lFound=True
+            else:
+                for iEntry,myEntry in enumerate(self.scos):
+                    if (myEntry.echoName()==myValue and isinstance(myEntry,Usrbdx) ):
                         lFound=True
                         break
         else:
@@ -319,6 +329,11 @@ class Geometry():
                     tmpBuf=tmpBuf+tmpLine
                     if(tmpLine.strip().endswith("&")):
                        newGeom.add(Usryield.fromBuf(tmpBuf.strip()),what="SCO")
+                       tmpBuf="" # flush buffer
+                elif (tmpLine.startswith("USRBDX")):
+                    tmpBuf=tmpBuf+tmpLine
+                    if(tmpLine.strip().endswith("&")):
+                       newGeom.add(Usrbdx.fromBuf(tmpBuf.strip()),what="SCO")
                        tmpBuf="" # flush buffer
                 elif (tmpLine.startswith("*")):
                     tmpBuf=tmpBuf+tmpLine
@@ -1542,10 +1557,10 @@ class Geometry():
         if (len(origScos)>0):
             print("duplicating scorings")
             allRegNames,iRegs=slicingGeo.ret("REG","ALL")
-            # USRYIELDs
+            # USRYIELDs and USRBDX
             for reg1name,reg2name in zip(allRegNames[0:-1],allRegNames[1:]):
                 for origSco in origScos:
-                    if (isinstance(origSco,Usryield)):
+                    if (isinstance(origSco,Usryield) or isinstance(origSco,Usrbdx)):
                         newSco=deepcopy(origSco)
                         newSco.setRegName(1,reg1name)
                         newSco.setRegName(2,reg2name)

--- a/geometry.py
+++ b/geometry.py
@@ -9,7 +9,7 @@ import grid
 from body import Body
 from region import Region
 from transformation import RotDefi, Transformation
-from scorings import Usrbin, Usryield, Usrbdx
+from scorings import Usrbin, Usryield, Usrbdx, Usrtrack, Usrcoll
 from FLUKA import HighLightComment, CheckString
 
 class Geometry():
@@ -251,6 +251,26 @@ class Geometry():
                     if (myEntry.echoName()==myValue and isinstance(myEntry,Usrbdx) ):
                         lFound=True
                         break
+        elif (myKey.upper().startswith("USRTRACK")):
+            if (myValue.upper()=="ALL"):
+                myEntry=[ mySco.echoName() for mySco in self.scos if isinstance(mySco,Usrtrack) ]
+                iEntry=[ ii for ii in range(len(self.scos)) ]
+                lFound=True
+            else:
+                for iEntry,myEntry in enumerate(self.scos):
+                    if (myEntry.echoName()==myValue and isinstance(myEntry,Usrtrack) ):
+                        lFound=True
+                        break
+        elif (myKey.upper().startswith("USRCOLL")):
+            if (myValue.upper()=="ALL"):
+                myEntry=[ mySco.echoName() for mySco in self.scos if isinstance(mySco,Usrcoll) ]
+                iEntry=[ ii for ii in range(len(self.scos)) ]
+                lFound=True
+            else:
+                for iEntry,myEntry in enumerate(self.scos):
+                    if (myEntry.echoName()==myValue and isinstance(myEntry,Usrcoll) ):
+                        lFound=True
+                        break
         else:
             print("%s not recognised! What should I look for in the geometry?"%(myKey))
             exit(1)
@@ -334,6 +354,16 @@ class Geometry():
                     tmpBuf=tmpBuf+tmpLine
                     if(tmpLine.strip().endswith("&")):
                        newGeom.add(Usrbdx.fromBuf(tmpBuf.strip()),what="SCO")
+                       tmpBuf="" # flush buffer
+                elif (tmpLine.startswith("USRTRACK")):
+                    tmpBuf=tmpBuf+tmpLine
+                    if(tmpLine.strip().endswith("&")):
+                       newGeom.add(Usrtrack.fromBuf(tmpBuf.strip()),what="SCO")
+                       tmpBuf="" # flush buffer
+                elif (tmpLine.startswith("USRCOLL")):
+                    tmpBuf=tmpBuf+tmpLine
+                    if(tmpLine.strip().endswith("&")):
+                       newGeom.add(Usrcoll.fromBuf(tmpBuf.strip()),what="SCO")
                        tmpBuf="" # flush buffer
                 elif (tmpLine.startswith("*")):
                     tmpBuf=tmpBuf+tmpLine
@@ -1557,13 +1587,20 @@ class Geometry():
         if (len(origScos)>0):
             print("duplicating scorings")
             allRegNames,iRegs=slicingGeo.ret("REG","ALL")
-            # USRYIELDs and USRBDX
+            # 2-reg based scoring cards:
             for reg1name,reg2name in zip(allRegNames[0:-1],allRegNames[1:]):
                 for origSco in origScos:
                     if (isinstance(origSco,Usryield) or isinstance(origSco,Usrbdx)):
                         newSco=deepcopy(origSco)
                         newSco.setRegName(1,reg1name)
                         newSco.setRegName(2,reg2name)
+                        slicingGeo.add(newSco,"SCO")
+            # 1-reg based scoring cards:
+            for regName in allRegNames:
+                for origSco in origScos:
+                    if (isinstance(origSco,Usrcoll) or isinstance(origSco,Usrtrack)):
+                        newSco=deepcopy(origSco)
+                        newSco.setRegName(regName)
                         slicingGeo.add(newSco,"SCO")
         # - rename geometry entities
         slicingGeo.rename(regName)

--- a/scorings.py
+++ b/scorings.py
@@ -317,16 +317,16 @@ class Usrbin(Scoring):
     def isLinkedToTransform(self):
         return self.retTransformName() is not None
     
-class Usryield(Scoring):
+class TwoRegBasedScoring(Scoring):
     '''
-    A very basic class for handling USRYIELD cards.
+    A very basic class for handling scoring cards with two regions.
     '''
-    def __init__(self,myName="",myComment=""):
-        Scoring.__init__(self,myName=myName,myComment=myComment,scoType="USRYIELD")
+    def __init__(self,myName="",myComment="",scoType=""):
+        Scoring.__init__(self,myName=myName,myComment=myComment,scoType=scoType)
 
     @staticmethod
-    def fromBuf(myBuffer):
-        return Scoring.fromBuf(myBuffer,newScoDet=Usryield())
+    def fromBuf(myBuffer,newScoDet):
+        return Scoring.fromBuf(myBuffer,newScoDet=newScoDet)
         
     def setRegName(self,whichReg,regName):
         if (whichReg==1 or whichReg==2):
@@ -347,3 +347,27 @@ class Usryield(Scoring):
             if (self.retRegName(iReg+1)==oldName):
                 self.setRegName(iReg+1,newName)
                 break
+
+class Usryield(TwoRegBasedScoring):
+    '''
+    A very basic class for handling USRYIELD cards.
+    '''
+    def __init__(self,myName="",myComment=""):
+        TwoRegBasedScoring.__init__(self,myName=myName,myComment=myComment,scoType="USRYIELD")
+
+    @staticmethod
+    def fromBuf(myBuffer):
+        return TwoRegBasedScoring.fromBuf(myBuffer,newScoDet=Usryield())
+        
+
+class Usrbdx(TwoRegBasedScoring):
+    '''
+    A very basic class for handling USRBDX cards.
+    '''
+    def __init__(self,myName="",myComment=""):
+        TwoRegBasedScoring.__init__(self,myName=myName,myComment=myComment,scoType="USRBDX")
+
+    @staticmethod
+    def fromBuf(myBuffer):
+        return TwoRegBasedScoring.fromBuf(myBuffer,newScoDet=Usrbdx())
+        

--- a/scorings.py
+++ b/scorings.py
@@ -319,7 +319,7 @@ class Usrbin(Scoring):
     
 class TwoRegBasedScoring(Scoring):
     '''
-    A very basic class for handling scoring cards with two regions.
+    A very basic class for handling region-based scoring cards with two regions.
     '''
     def __init__(self,myName="",myComment="",scoType=""):
         Scoring.__init__(self,myName=myName,myComment=myComment,scoType=scoType)
@@ -342,8 +342,8 @@ class TwoRegBasedScoring(Scoring):
         else:
             print("Usryield.retRegName(): which region do you choose?")
             exit(1)
-    def regNameReplaceInDef(self,oldName,newName):
-        for iReg in range(2):
+    def regNameReplaceInDef(self,oldName,newName,nRegs=2):
+        for iReg in range(nRegs):
             if (self.retRegName(iReg+1)==oldName):
                 self.setRegName(iReg+1,newName)
                 break
@@ -371,3 +371,39 @@ class Usrbdx(TwoRegBasedScoring):
     def fromBuf(myBuffer):
         return TwoRegBasedScoring.fromBuf(myBuffer,newScoDet=Usrbdx())
         
+class Usrtrack(TwoRegBasedScoring):
+    '''
+    A very basic class for handling USRTRACK cards.
+    '''
+    def __init__(self,myName="",myComment=""):
+        TwoRegBasedScoring.__init__(self,myName=myName,myComment=myComment,scoType="USRTRACK")
+
+    @staticmethod
+    def fromBuf(myBuffer):
+        return TwoRegBasedScoring.fromBuf(myBuffer,newScoDet=Usrtrack())
+        
+    def setRegName(self,regName):
+        TwoRegBasedScoring.setRegName(self,1,regName)
+    def retRegName(self):
+        return TwoRegBasedScoring.retRegName(self,1)
+    def regNameReplaceInDef(self,oldName,newName):
+        TwoRegBasedScoring.regNameReplaceInDef(self,oldName,newName,nRegs=1)
+
+class Usrcoll(TwoRegBasedScoring):
+    '''
+    A very basic class for handling USRCOLL cards.
+    '''
+    def __init__(self,myName="",myComment=""):
+        TwoRegBasedScoring.__init__(self,myName=myName,myComment=myComment,scoType="USRCOLL")
+
+    @staticmethod
+    def fromBuf(myBuffer):
+        return TwoRegBasedScoring.fromBuf(myBuffer,newScoDet=Usrcoll())
+        
+    def setRegName(self,regName):
+        TwoRegBasedScoring.setRegName(self,1,regName)
+    def retRegName(self):
+        return TwoRegBasedScoring.retRegName(self,1)
+    def regNameReplaceInDef(self,oldName,newName):
+        TwoRegBasedScoring.regNameReplaceInDef(self,oldName,newName,nRegs=1)
+


### PR DESCRIPTION
Support for `USRYIELD`, `USRBDX`, `USRCOLL` and `USRTRACK` cards.
The implementation is based on a parent class, able to modify the two regions of a boundary-crossing scoring.

At the same time, a dedicated function for name creation based on FLUKA naming rules.
