### PR TITLE
Getting ready for automatically inserting replicas prototypes into the VIF geometry

### DIFF
--- a/body.py
+++ b/body.py
@@ -51,8 +51,9 @@ class Body(GeoObject):
         elif (self.bType=="ZCC"):
             myFloats=list(self.P[0:-1])+[self.Rs[0]]
         elif (self.bType=="RPP"):
-            myFloats=list(self.P)+list(self.P+self.V)
-            myFloats[1::2]=myFloats[3:]
+            myFloats=[0.0 for ii in range(6)]
+            myFloats[::2]=list(self.P)
+            myFloats[1::2]=list(self.P+self.V)
         else:
             print("body %s NOT supported yet!"%(self.bType))
             exit(1)

--- a/region.py
+++ b/region.py
@@ -64,7 +64,7 @@ class Region(GeoObject):
         for oName,nName in zip(oldNames,newNames):
             self.definition=self.definition.replace(oName,nName)
 
-    def assignMat(self,myMaterial):
+    def assignMat(self,myMaterial="VACUUM"):
         self.material=myMaterial
 
     def assignLat(self,myLatName=None):

--- a/region.py
+++ b/region.py
@@ -27,7 +27,7 @@ class Region(GeoObject):
         # additional fields
         self.initCont()
 
-    def initCont(self,rCont=0,rCent=np.array([0.0,0.0,0.0]),rMaxLen=0.0):
+    def initCont(self,rCont=0,rCent=np.zeros(3),rMaxLen=0.0):
         self.rCont=rCont # containment indicator (1 per region):
                          # -1: region to be contained into/sized by another one
                          #  0: regular region (neither contains nor it is contained)


### PR DESCRIPTION
In particular:
* inserting a geometry into another one. More than a containing/contained region can be requested, but not at the same time;
* merging geometries possible also based on region flagging only, without matching region cetres;

Minor changes:
* default material assignment to `VACUUM` when calling `Region.assignMat()` method;
* possibility to parse `ROT-DEFI` cards in `FIXED` format where some `WHAT`s have default values, i.e. not typed in;
* crunching of `LATTICE` cards in `.inp` being parsed;
* more than a region per `ASSIGNMA` card (including stepping);

Bug fixes:
* bug fix in `RPP` printing;
* a possible bug in the python garbage collector when initializing a `RotDefi` instance;
* typo in the interface of the `Transformation.fromBuf()` method;
* bug fix in parsing `ROT-DEFI` cards in `.inp` being parsed;
* bug fix in parsing a `.inp` file with pre-processing flags;