### PR TITLE
Bug fix in `Geometry.SolidTransform()`

### DIFF
--- a/body.py
+++ b/body.py
@@ -258,8 +258,11 @@ class Body(GeoObject):
             if (lDebug):
                 print("...converted body %s into an %s"%(myStr,self.bType))
 
-    def traslate(self,dd=None):
+    def traslate(self,dd=None,lDebug=False):
         if (dd is not None):
+            if (lDebug):
+                myStr="%-3s %8s"%(self.bType,self.echoName())
+                print("applying traslation array [%g,%g,%g] to body %s..."%(dd[0],dd[1],dd[2],myStr))
             self.P=self.P+dd
         else:
             print("please provide me with a 3D traslation array!")
@@ -267,6 +270,9 @@ class Body(GeoObject):
                 
     def rotate(self,myMat=None,myTheta=None,myAxis=3,lDegs=True,lDebug=False):
         if (myMat is not None):
+            if (lDebug):
+                myStr="%-3s %8s"%(self.bType,self.echoName())
+                print("applying rotation matrix to body %s..."%(myStr))
             self.P=myMat.mulArr(self.P,lDebug=lDebug)
             self.V=myMat.mulArr(self.V,lDebug=lDebug)
             # DIRTY PATCH TO ROTATE RPPs by 90degs and multiples:
@@ -280,6 +286,9 @@ class Body(GeoObject):
                 print("you must specify a rotation axis together with an angle!")
                 exit(1)
             else:
+                if (lDebug):
+                    myStr="%-3s %8s"%(self.bType,self.echoName())
+                    print("applying rotation by %g degs on axis %d to body %s..."%(myTheta,myAxis,myStr))
                 myMat=RotMat(myAng=myTheta,myAxis=myAxis,lDegs=lDegs,lDebug=lDebug)
                 self.rotate(myMat=myMat,myTheta=None,myAxis=myAxis,lDegs=lDegs,lDebug=lDebug)
 
@@ -288,7 +297,7 @@ class Body(GeoObject):
            origCenter=self.retCenter()
            orient=self.retOrient()
            if (lDebug):
-               myStr=GeoObject.echoComm(self)+"%-3s %8s"%(self.bType,self.echoName())
+               myStr="%-3s %8s"%(self.bType,self.echoName())
                print("...resizing body %s to L=%g cm..."%(myStr,newL))
                oldP=self.P
                oldV=self.V

--- a/geometry.py
+++ b/geometry.py
@@ -11,6 +11,7 @@ from region import Region
 from transformation import RotDefi, Transformation
 from scorings import Usrbin, Usryield, Usrbdx, Usrtrack, Usrcoll
 from FLUKA import HighLightComment, TailNameInt
+from myMath import RotMat
 
 class Geometry():
     '''
@@ -787,8 +788,9 @@ class Geometry():
                     print("...applying rotation by %f degs around axis %d..."%\
                           (myTheta,myAxis))
                     if (not lGeoDirs):
+                        myMat=RotMat(myAng=myTheta,myAxis=myAxis,lDegs=lDegs,lDebug=lDebug)
                         for myBod in self.bods:
-                            myBod.rotate(myMat=None,myTheta=myTheta,myAxis=myAxis,lDegs=lDegs,lDebug=lDebug)
+                            myBod.rotate(myMat=myMat,myTheta=None,myAxis=None,lDegs=lDegs,lDebug=lDebug)
                     ROTDEFIlist.append(RotDefi(myAx=myAxis,myTh=myTheta))
                     if (lWrapGeo): ROTDEFIlistINV.append(RotDefi(myAx=myAxis,myTh=-myTheta))
             if (dd is not None):
@@ -796,14 +798,17 @@ class Geometry():
                       (dd[0],dd[1],dd[2]))
                 if (not lGeoDirs):
                     for myBod in self.bods:
-                        myBod.traslate(dd=dd)
+                        myBod.traslate(dd=dd,lDebug=lDebug)
                 myDD=dd
                 if (isinstance(myDD,list)):
                     myDD=np.array(dd)
-                myDD=-myDD
-                ROTDEFIlist.append(RotDefi(myDD=myDD))
-                if (lWrapGeo): ROTDEFIlistINV.append(RotDefi(myDD=-myDD))
+                ROTDEFIlist.append(RotDefi(myDD=-myDD))
+                if (lWrapGeo): ROTDEFIlistINV.append(RotDefi(myDD=myDD))
             if (len(ROTDEFIlist)>0):
+                if (lDebug):
+                    print("...final list of ROT-DEFI cards (as in memory):")
+                    for tmpRotDefi in ROTDEFIlist:
+                        print(tmpRotDefi.echo(myID=1,myName="ignore_myName_myIndex"))
                 # add transformation:
 
                 # bodies
@@ -827,7 +832,7 @@ class Geometry():
                     for myTrasName in tTrasfs:
                         if (lDebug): print("...updating BODY %s ROT-DEFI cards..."%(myTrasName))
                         myTras,iEntry=self.ret("transf",myTrasName)
-                        myTras.AddRotDefis(reversed(deepcopy(ROTDEFIlist)),iAdd=0)
+                        myTras.AddRotDefis(deepcopy(ROTDEFIlist),iAdd=0)
                     # add comment, in case
                     if (lCreate and myComment is not None):
                         myEntry,iEntry=self.ret("TRANSF",Tname)
@@ -854,7 +859,7 @@ class Geometry():
                 for myTrasName in tTrasfs:
                     if (lDebug): print("...updating LATTICE %s ROT-DEFI cards..."%(myTrasName))
                     myTras,iEntry=self.ret("transf",myTrasName)
-                    myTras.AddRotDefis(reversed(deepcopy(ROTDEFIlist)),iAdd=0)
+                    myTras.AddRotDefis(deepcopy(ROTDEFIlist),iAdd=0)
                     if (lWrapGeo):
                         if (lDebug): print("    ...wrapped!")
                         myTras.AddRotDefis(reversed(deepcopy(ROTDEFIlistINV)),iAdd=-1)
@@ -889,7 +894,7 @@ class Geometry():
                     for myTrasName in tTrasfs:
                         if (lDebug): print("...updating USRBIN %s ROT-DEFI cards..."%(myTrasName))
                         myTras,iEntry=self.ret("transf",myTrasName)
-                        myTras.AddRotDefis(reversed(deepcopy(ROTDEFIlist)),iAdd=0)
+                        myTras.AddRotDefis(deepcopy(ROTDEFIlist),iAdd=0)
                     # add comment, in case
                     if (lCreate and myComment is not None):
                         myEntry,iEntry=self.ret("TRANSF",Tname)


### PR DESCRIPTION
`ROT-DEFI` cards are always headed to existing transformations one by one, effectively making useless the `reverse` command.

Moreover, added some debugging output to `Body.traslate()`